### PR TITLE
Update Rust edition from 2021 to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-template"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [lib]
 name = "rust_template"

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -5,15 +5,15 @@ use std::path::Path;
 use std::str::FromStr;
 
 // crates.io
-use time::{format_description, UtcOffset};
+use time::{UtcOffset, format_description};
 use tracing::Level;
 pub use tracing::{debug, error, info, trace, warn};
 use tracing_appender::{non_blocking, rolling};
 use tracing_panic::panic_hook;
 use tracing_subscriber::fmt::time::OffsetTime;
 use tracing_subscriber::{
-    filter::LevelFilter, fmt, layer::SubscriberExt, reload, util::SubscriberInitExt, Layer,
-    Registry,
+    Layer, Registry, filter::LevelFilter, fmt, layer::SubscriberExt, reload,
+    util::SubscriberInitExt,
 };
 
 // This library

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,12 +36,12 @@ fn main() -> ErrorCode {
             if error_code != ErrorCode::Success {
                 return error_code;
             }
-            let error_code = runtime::Builder::new_multi_thread()
+
+            runtime::Builder::new_multi_thread()
                 .enable_all()
                 .build()
                 .unwrap()
-                .block_on(main_async());
-            error_code
+                .block_on(main_async())
         }
         Err(err_code) => err_code,
     };

--- a/src/threads/signal_handler.rs
+++ b/src/threads/signal_handler.rs
@@ -1,7 +1,7 @@
 // crates.io
 use cfg_if::cfg_if;
 #[cfg(unix)]
-use tokio::signal::unix::{signal, SignalKind};
+use tokio::signal::unix::{SignalKind, signal};
 #[cfg(windows)]
 use tokio::signal::windows::{ctrl_break, ctrl_c, ctrl_close};
 use tokio::sync::broadcast::{self, error::RecvError};


### PR DESCRIPTION
## Summary
- Update Rust edition from 2021 to 2024 (stable since Rust 1.85)
- Apply edition 2024 import sorting rules and remove unnecessary let binding

## Test plan
- [x] `cargo build` passes
- [x] `cargo clippy` passes with no warnings
- [x] `cargo test` passes
- [x] `cargo fmt --all -- --check` passes