### PR TITLE
Use interval tick instead of sleep in producer

### DIFF
--- a/src/threads/producer.rs
+++ b/src/threads/producer.rs
@@ -14,11 +14,12 @@ pub async fn start(
     mut cmd_receiver: broadcast::Receiver<ThreadCommand>,
     data_sender: mpsc::UnboundedSender<i32>,
 ) -> Result<(), ErrorCode> {
+    let mut interval = time::interval(Duration::from_secs(1));
     let mut counter = 0;
     let mut loop_running = true;
     while loop_running {
         tokio::select! {
-            _ = time::sleep(Duration::from_secs(1)) => {
+            _ = interval.tick() => {
                 counter += 1;
                 info!("Produce: {}", counter);
                 if let Err(err) = data_sender.send(counter) {


### PR DESCRIPTION
## Summary
- Replace `time::sleep()` with `Interval::tick()` in producer thread for consistent periodic timing
- `sleep()` in a `select!` loop causes timer reset on command reception and cumulative drift from processing time
- `tick()` tracks absolute time points, ensuring stable 1-second intervals regardless of processing overhead or command interruptions

Closes #25

## Test plan
- [x] `cargo build` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [x] Run the application and verify producer outputs at consistent 1-second intervals