### PR TITLE
Improve CI workflow: remove placeholder and enable macOS and declare MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Apt update on Ubuntu
-        run: sudo apt update
       - name: Install dependencies on Ubuntu
-        run: echo "CHANGE COMMAND HERE TO INSTALL DEPENDENCIES"
+        if: false  # TODO: Enable and configure when dependencies are needed
+        run: "sudo apt update && sudo apt install -y <packages>"
       - name: Update toolchain
         run: rustup update --no-self-update stable && rustup default stable
       - name: Run cargo fmt --all -- --check
@@ -53,10 +52,9 @@ jobs:
         uses: actions/checkout@v4
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
-      - name: Apt update on Ubuntu
-        run: sudo apt update
       - name: Install dependencies on Ubuntu
-        run: echo "CHANGE COMMAND HERE TO INSTALL DEPENDENCIES"
+        if: false  # TODO: Enable and configure when dependencies are needed
+        run: "sudo apt update && sudo apt install -y <packages>"
       - name: Update toolchain
         run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
       - name: Run cargo build --release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
         rust: [stable]
         runs-on:
           - windows-latest
-          # - macos-latest
+          - macos-latest
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rust-template"
 version = "0.1.0"
 edition = "2024"
+rust-version = "1.85"
 
 [lib]
 name = "rust_template"


### PR DESCRIPTION
## Summary
- Replace placeholder `echo "CHANGE COMMAND HERE..."` install step with `if: false` disabled step to prevent silent no-op on fork
- Enable macOS in the `build-others` CI matrix to match active development platform
- Declare `rust-version = "1.85"` in `Cargo.toml` for edition 2024 compatibility

Closes #42

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] `cargo test` passes
- [x] CI workflow runs successfully on this PR